### PR TITLE
Add support for custom probe path

### DIFF
--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
@@ -18,9 +18,17 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
                 {
                     // Assume plugins sit in a plugins directory next to the current assembly.
 #if AUTOANALYSIS_EXTENSIBILITY
-                    s_analyzersDirectory = Path.Combine(
-                        Path.GetDirectoryName(typeof(AnalyzerResolver).Assembly.Location),
-                        AnalyzersDirectoryName);
+                    string probePath = Environment.GetEnvironmentVariable("TRACEEVENT_ANALYZER_PATH");
+                    if (!string.IsNullOrEmpty(probePath))
+                    {
+                        s_analyzersDirectory = probePath;
+                    }
+                    else
+                    {
+                        s_analyzersDirectory = Path.Combine(
+                            Path.GetDirectoryName(typeof(AnalyzerResolver).Assembly.Location),
+                            AnalyzersDirectoryName);
+                    }
 #endif
                 }
                 return s_analyzersDirectory;

--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
             }
 
             string[] candidateAssemblies = Directory.GetFiles(AnalyzersDirectory, "*.dll", SearchOption.TopDirectoryOnly);
-            foreach(string candidateAssembly in candidateAssemblies)
+            foreach (string candidateAssembly in candidateAssemblies)
             {
                 // If an assembly with the same identity is already loaded,
                 // LoadFrom will return the loaded assembly even if a different path was specified.

--- a/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AnalyzerResolver.cs
@@ -7,9 +7,12 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
 {
     internal sealed class AnalyzerResolver
     {
+        /// <summary>
+        /// This is the child directory to search in if <see cref="AnalyzersDirectory"/> is not explicitly set.
+        /// </summary>
         private const string AnalyzersDirectoryName = "Analyzers";
-        private static string s_analyzersDirectory;
 
+        private static string s_analyzersDirectory;
         internal static string AnalyzersDirectory
         {
             get

--- a/src/TraceEvent/AutomatedAnalysis/AutomatedAnalysisManager.cs
+++ b/src/TraceEvent/AutomatedAnalysis/AutomatedAnalysisManager.cs
@@ -9,11 +9,15 @@ namespace Microsoft.Diagnostics.Tracing.AutomatedAnalysis
         private IEnumerable<Analyzer> _analyzers;
         private Configuration _configuration;
 
-        public AutomatedAnalysisManager()
+        /// <summary>
+        /// Constructs the AutomatedAnalysisManager.
+        /// </summary>
+        /// <param name="probePath">(optional) A path to search for analyzers and configuration files.</param>
+        public AutomatedAnalysisManager(string probePath = null)
         {
+            AnalyzerResolver.AnalyzersDirectory = probePath;
             _analyzers = AnalyzerResolver.GetAnalyzers();
             _configuration = AnalyzerResolver.GetConfiguration();
-
         }
 
         public AutomatedAnalysisResult ProcessTrace(ITrace trace, TextWriter textLog)


### PR DESCRIPTION
Current behavior was probing relative to the TraceEvent.dll. This change allows whoever is instantiating the analysis manager to pass in their own path for probing analyzers and configuration.